### PR TITLE
Add publish docker action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,34 @@
+name: Publish Docker
+
+on:
+  push:
+    branches:
+      - '6.0'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: wh2099/olaindex:latest


### PR DESCRIPTION
利用 Github Actions 提供便利、及时、透明的自动化 Docker 构建及发布（https://hub.docker.com/）。

使用方式：

1. 在 docker hub 中生成新的 token （https://hub.docker.com/settings/security）
2. 在仓库中设置两个 secrets：
                                                DOCKERHUB_USERNAME （值为您的 docker 用户名）
                                                DOCKERHUB_TOKEN （值为刚才获取的 token）
3. 合并此 PR 即可

另注：我已经对此功能进行了测试，目前构建发布的结果在 https://hub.docker.com/r/wh2099/olaindex