### PR TITLE
修正mdui的自动黑暗模式

### DIFF
--- a/public/css/mdui.css
+++ b/public/css/mdui.css
@@ -7,6 +7,10 @@ body {
     font-family: Roboto, Noto Sans SC, Noto, Helvetica, Arial, sans-serif
 }
 
+body a {
+    color: pink  
+}
+
 .mdui-container {
     max-width: 950px
 }

--- a/public/css/mdui.css
+++ b/public/css/mdui.css
@@ -8,7 +8,11 @@ body {
 }
 
 body a {
-    color: pink  
+    color: #FFB6C1
+}
+
+body a:hover {
+    color: 	#DC143C
 }
 
 .mdui-container {

--- a/resources/views/mdui/layouts/main.blade.php
+++ b/resources/views/mdui/layouts/main.blade.php
@@ -43,7 +43,7 @@
         }
     </script>
 </head>
-<body class="mdui-appbar-with-toolbar mdui-theme-layout-auto mdui-theme-accent-pink mdui-loaded">
+<body class="mdui-appbar-with-toolbar mdui-theme-accent-pink mdui-loaded">
 <div id="top" class="anchor"></div>
 @include('mdui.layouts.appbar')
 @include('mdui.layouts.drawer')
@@ -72,10 +72,20 @@
     const $ = mdui.$
     window.mdui = mdui
     window.theme = {
+        theme_init: () => {
+	    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                store.set('darkMode', true)
+                $('body').addClass('mdui-theme-layout-dark')
+            } else {
+                store.set('darkMode', false)
+                $('body').removeClass('mdui-theme-layout-dark')
+            }
+	},
         toggle_theme: () => {
             let darkMode = store.get('darkMode')
             if (typeof (darkMode) == 'undefined' || darkMode === null) {
-                darkMode = false
+                theme_init();
+        	toggle_theme();
             }
             if (darkMode) {
                 $('body').removeClass('mdui-theme-layout-dark')
@@ -85,29 +95,9 @@
                 store.set('darkMode', true)
             }
         },
-        mutation: () => {
-            $('body').removeClass('mdui-theme-layout-auto')
-            let darkMode = store.get('darkMode')
-            if (typeof (darkMode) == 'undefined' || darkMode === null) {
-                if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-                    store.set('darkMode', true)
-                    $('body').addClass('mdui-theme-layout-dark')
-                } else {
-                    store.set('darkMode', false)
-                    $('body').removeClass('mdui-theme-layout-dark')
-                }
-            }
-            if (!darkMode) {
-                $('body').removeClass('mdui-theme-layout-dark')
-                store.set('darkMode', false)
-            } else {
-                $('body').addClass('mdui-theme-layout-dark')
-                store.set('darkMode', true)
-            }
-        },
-    }
+    };
     $(function() {
-        window.theme.mutation()
+        window.theme.theme_init()
         let clipboard = new ClipboardJS('.clipboard')
         clipboard.on('success', function(e) {
             mdui.snackbar({


### PR DESCRIPTION
不清楚mdui主题原来是否有黑暗模式自动切换的功能, 增添一下. 
打开网页时无视localstorage存有的信息直接根据系统的设定改变黑暗模式. 也保留手动切换的功能.
优化了mdui主题超链接的颜色. (改为粉色我觉得比较好看. 蓝色太突兀了)